### PR TITLE
CIS-3351 Configurable Email Subject Prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- README documentation on configurable properties (CIS-3349)
-- README documentation on SMTP and Twilio delivery strategies (AUTHLIB-162)
+- README documentation on configurable properties. (CIS-3349)
+- README documentation on SMTP and Twilio delivery strategies. (AUTHLIB-162)
+- Add configuration property for default email sender address. (CIS-3351)
+- Add configuration property for email subject prefix. (CIS-3351)
+- Prepend email subject prefix to the subject of outgoing email messages. (CIS-3351)
+- **Breaking**: Add a method to the `EmailDeliveryStrategy` interface that sends email using the default sender address. (CIS-3351)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Configure the following properties for your applications's use case:
 |---|---|---|---|
 |octri.messaging.enabled|boolean|TRUE|Whether the messaging library is enabled.|
 |octri.messaging.email-delivery-method|enum|LOG|Dictates how emails will be sent. Options are LOG (log without sending). NOOP (do nothing), and SMTP (send via SMTP)|
+|octri.messaging.email.default-sender-address|string|None|The default email address to use if the sender address is not specified.|
+|octri.messaging.email.subject-prefix|string|None|Optional prefix to add to the subject line of all email messages.|
 |octri.messaging.sms-delivery-method|enum|LOG|Dictates how texts will be sent. Options are LOG (log without sending). NOOP (do nothing), and TWILIO (send via Twilio)|
 |octri.messaging.twilio.account-sid|string|None|The Twilio account sid. Only required if SMS delivery method is TWILIO|
 |octri.messaging.twilio.auth-token|string|None|The Twilio OAuth token. Only required if SMS delivery method is TWILIO|

--- a/src/main/java/org/octri/messaging/autoconfig/EmailProperties.java
+++ b/src/main/java/org/octri/messaging/autoconfig/EmailProperties.java
@@ -1,0 +1,56 @@
+package org.octri.messaging.autoconfig;
+
+/**
+ * Properties used to configure the email delivery strategy.
+ */
+public class EmailProperties {
+
+	/**
+	 * Default sender email address.
+	 */
+	private String defaultSenderAddress;
+
+	/**
+	 * Email subject prefix.
+	 */
+	private String subjectPrefix;
+
+	/**
+	 * Gets the email address used if a sender address is not provided.
+	 *
+	 * @return the default sender address
+	 */
+	public String getDefaultSenderAddress() {
+		return defaultSenderAddress;
+	}
+
+	/**
+	 * Sets the email address used if a sender address is not provided.
+	 *
+	 * @param defaultSenderAddress
+	 *            the address to use
+	 */
+	public void setDefaultSenderAddress(String defaultSenderAddress) {
+		this.defaultSenderAddress = defaultSenderAddress;
+	}
+
+	/**
+	 * Gets the prefix added to email subject lines. May be blank.
+	 *
+	 * @return the subject prefix
+	 */
+	public String getSubjectPrefix() {
+		return subjectPrefix;
+	}
+
+	/**
+	 * Sets the prefix added to email subject lines. May be blank.
+	 *
+	 * @param subjectPrefix
+	 *            the prefix to use
+	 */
+	public void setSubjectPrefix(String subjectPrefix) {
+		this.subjectPrefix = subjectPrefix;
+	}
+
+}

--- a/src/main/java/org/octri/messaging/autoconfig/MessagingProperties.java
+++ b/src/main/java/org/octri/messaging/autoconfig/MessagingProperties.java
@@ -54,6 +54,11 @@ public class MessagingProperties {
 	private boolean enabled = true;
 
 	/**
+	 * Properties to configure the email delivery strategy.
+	 */
+	private EmailProperties email;
+
+	/**
 	 * How email messages should be delivered. Defaults to sending messages to the log.
 	 */
 	private EmailDeliveryMethod emailDeliveryMethod = EmailDeliveryMethod.LOG;
@@ -85,6 +90,25 @@ public class MessagingProperties {
 	 */
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	/**
+	 * Gets the email configuration properties.
+	 * 
+	 * @return email configuration
+	 */
+	public EmailProperties getEmail() {
+		return email;
+	}
+
+	/**
+	 * Sets the email configuration properties.
+	 * 
+	 * @param email
+	 *            email configuration
+	 */
+	public void setEmail(EmailProperties email) {
+		this.email = email;
 	}
 
 	/**

--- a/src/main/java/org/octri/messaging/email/EmailDeliveryStrategy.java
+++ b/src/main/java/org/octri/messaging/email/EmailDeliveryStrategy.java
@@ -29,4 +29,21 @@ public interface EmailDeliveryStrategy {
 	 */
 	public Optional<String> sendEmail(String fromEmail, String toEmail, String messageSubject, String messageText);
 
+	/**
+	 * Sends an email message from the default sender address. Implementations may optionally return a string
+	 * representation of the delivery details. Implementations should throw {@link UnsuccessfulDeliveryException} when
+	 * delivery is unsuccessful to allow callers to respond to delivery failure.
+	 *
+	 * @param toEmail
+	 *            recipient email address
+	 * @param messageSubject
+	 *            subject of the message
+	 * @param messageText
+	 *            body text of the message
+	 * @return optional string representation of the delivery details, e.g. API response from a transactional mail
+	 *         service
+	 * @throws UnsuccessfulDeliveryException
+	 *             delivery failure details
+	 */
+	public Optional<String> sendEmail(String toEmail, String messageSubject, String messageText);
 }

--- a/src/main/java/org/octri/messaging/email/EmailUtils.java
+++ b/src/main/java/org/octri/messaging/email/EmailUtils.java
@@ -1,0 +1,26 @@
+package org.octri.messaging.email;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utilities for working with email messages.
+ */
+public class EmailUtils {
+
+	/**
+	 * Adds a prefix to the given message subject, if the prefix is defined and is not already present.
+	 *
+	 * @param messageSubject
+	 *            email message subject
+	 * @param prefix
+	 *            optional prefix string
+	 * @return the message subject with the prefix added, or the original message subject
+	 */
+	public static String addPrefixToSubject(String messageSubject, String prefix) {
+		var trimmedPrefix = StringUtils.trimToEmpty(prefix);
+		return StringUtils.isNotBlank(trimmedPrefix) && !messageSubject.startsWith(trimmedPrefix)
+				? trimmedPrefix + " " + messageSubject
+				: messageSubject;
+	}
+
+}

--- a/src/main/java/org/octri/messaging/email/LoggingEmailDeliveryStrategy.java
+++ b/src/main/java/org/octri/messaging/email/LoggingEmailDeliveryStrategy.java
@@ -2,8 +2,13 @@ package org.octri.messaging.email;
 
 import java.util.Optional;
 
+import org.octri.messaging.autoconfig.EmailProperties;
+import org.octri.messaging.exception.UnsuccessfulDeliveryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
+import io.micrometer.common.util.StringUtils;
 
 /**
  * Mock email delivery strategy for development environments that logs messages
@@ -13,15 +18,42 @@ public class LoggingEmailDeliveryStrategy implements EmailDeliveryStrategy {
 
 	private static final Logger log = LoggerFactory.getLogger(LoggingEmailDeliveryStrategy.class);
 
+	private final EmailProperties emailProperties;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param emailProperties
+	 *            email configuration properties
+	 */
+	public LoggingEmailDeliveryStrategy(EmailProperties emailProperties) {
+		Assert.notNull(emailProperties, "Email configuration properties are required for the logging delivery strategy."
+				+ " Check the octri.messaging.email configuration.");
+		this.emailProperties = emailProperties;
+	}
+
 	/**
 	 * Logs the message to the console for inspection.
 	 */
 	@Override
 	public Optional<String> sendEmail(String fromEmail, String toEmail, String messageSubject, String messageText) {
+		var prefixedSubject = EmailUtils.addPrefixToSubject(messageSubject, emailProperties.getSubjectPrefix());
 		log.info("Mock email from {} to {}", fromEmail, toEmail);
-		log.info("Mock message subject: " + messageSubject);
+		log.info("Mock message subject: " + prefixedSubject);
 		log.info("Mock message text:\n" + messageText);
 		return Optional.empty();
+	}
+
+	/**
+	 * Logs the message for the console for inspection, using the default sender address.
+	 */
+	@Override
+	public Optional<String> sendEmail(String toEmail, String messageSubject, String messageText) {
+		if (StringUtils.isBlank(emailProperties.getDefaultSenderAddress())) {
+			throw new UnsuccessfulDeliveryException(
+					"The default sender address is required to send email without a from address.");
+		}
+		return sendEmail(emailProperties.getDefaultSenderAddress(), toEmail, messageSubject, messageText);
 	}
 
 }

--- a/src/main/java/org/octri/messaging/email/NoopEmailDeliveryStrategy.java
+++ b/src/main/java/org/octri/messaging/email/NoopEmailDeliveryStrategy.java
@@ -13,4 +13,9 @@ public class NoopEmailDeliveryStrategy implements EmailDeliveryStrategy {
 		return Optional.empty();
 	}
 
+	@Override
+	public Optional<String> sendEmail(String toEmail, String messageSubject, String messageText) {
+		return Optional.empty();
+	}
+
 }

--- a/src/main/java/org/octri/messaging/email/SmtpEmailDeliveryStrategy.java
+++ b/src/main/java/org/octri/messaging/email/SmtpEmailDeliveryStrategy.java
@@ -2,6 +2,7 @@ package org.octri.messaging.email;
 
 import java.util.Optional;
 
+import org.octri.messaging.autoconfig.EmailProperties;
 import org.octri.messaging.exception.UnsuccessfulDeliveryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,8 @@ import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.util.Assert;
+
+import io.micrometer.common.util.StringUtils;
 
 /**
  * Email delivery strategy that uses an SMTP server to send messages.
@@ -26,30 +29,37 @@ public class SmtpEmailDeliveryStrategy implements EmailDeliveryStrategy {
 
 	private static final Logger log = LoggerFactory.getLogger(SmtpEmailDeliveryStrategy.class);
 
-	private JavaMailSender sender;
+	private final JavaMailSender sender;
+	private final EmailProperties emailProperties;
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param sender
 	 *            java mail sender
+	 * @param emailProperties
+	 *            email configuration properties
 	 */
-	public SmtpEmailDeliveryStrategy(JavaMailSender sender) {
+	public SmtpEmailDeliveryStrategy(JavaMailSender sender, EmailProperties emailProperties) {
 		Assert.notNull(sender, "A JavaMailSender bean is required for the SMTP delivery strategy."
 				+ " Check the spring.mail configuration");
+		Assert.notNull(emailProperties, "Email configuration properties are required for the SMTP delivery strategy."
+				+ " Check the octri.messaging.email configuration.");
 		this.sender = sender;
+		this.emailProperties = emailProperties;
 	}
 
 	@Override
 	public Optional<String> sendEmail(String fromEmail, String toEmail, String messageSubject, String messageText) {
+		var prefixedSubject = EmailUtils.addPrefixToSubject(messageSubject, emailProperties.getSubjectPrefix());
 		log.debug("Sending SMTP email from {} to {}", fromEmail, toEmail);
-		log.debug("Message subject: " + messageSubject);
+		log.debug("Message subject: " + prefixedSubject);
 		log.debug("Message text:\n" + messageText);
 
 		var message = new SimpleMailMessage();
 		message.setFrom(fromEmail);
 		message.setTo(toEmail);
-		message.setSubject(messageSubject);
+		message.setSubject(prefixedSubject);
 		message.setText(messageText);
 
 		try {
@@ -60,4 +70,14 @@ public class SmtpEmailDeliveryStrategy implements EmailDeliveryStrategy {
 
 		return Optional.empty();
 	}
+
+	@Override
+	public Optional<String> sendEmail(String toEmail, String messageSubject, String messageText) {
+		if (StringUtils.isBlank(emailProperties.getDefaultSenderAddress())) {
+			throw new UnsuccessfulDeliveryException(
+					"The default sender address is required to send email without a from address.");
+		}
+		return sendEmail(emailProperties.getDefaultSenderAddress(), toEmail, messageSubject, messageText);
+	}
+
 }

--- a/src/test/java/org/octri/messaging/email/EmailUtilsTest.java
+++ b/src/test/java/org/octri/messaging/email/EmailUtilsTest.java
@@ -1,0 +1,49 @@
+package org.octri.messaging.email;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class EmailUtilsTest {
+
+	private static final String PREFIX = "secure:";
+	private static final String INPUT_SUBJECT = "Subject";
+	private static final String EXPECTED_SUBJECT = PREFIX + " " + INPUT_SUBJECT;
+
+	@Test
+	public void testAddPrefixToSubject() {
+		assertEquals(EXPECTED_SUBJECT, EmailUtils.addPrefixToSubject(INPUT_SUBJECT, PREFIX),
+				"The prefix is prepended to the subject string.");
+	}
+
+	@Test
+	public void testAddPrefixToSubjectTrimsPrefix() {
+		assertEquals(EXPECTED_SUBJECT, EmailUtils.addPrefixToSubject(INPUT_SUBJECT, " " + PREFIX),
+				"Padding is trimmed before appending the prefix to the subject string.");
+
+		assertEquals(EXPECTED_SUBJECT, EmailUtils.addPrefixToSubject(INPUT_SUBJECT, PREFIX + " "),
+				"Padding is trimmed before appending the prefix to the subject.");
+
+		assertEquals(EXPECTED_SUBJECT, EmailUtils.addPrefixToSubject(INPUT_SUBJECT, " " + PREFIX + " "),
+				"Padding is trimmed before appending the prefix to the subject.");
+	}
+
+	@Test
+	public void testAddPrefixToSubjectIgnoresBlankPrefix() {
+		assertEquals(INPUT_SUBJECT, EmailUtils.addPrefixToSubject(INPUT_SUBJECT, ""),
+				"Subject is unchanged if prefix is empty.");
+
+		assertEquals(INPUT_SUBJECT, EmailUtils.addPrefixToSubject(INPUT_SUBJECT, "     "),
+				"Subject is unchanged if prefix is blank.");
+
+		assertEquals(INPUT_SUBJECT, EmailUtils.addPrefixToSubject(INPUT_SUBJECT, null),
+				"Subject is unchanged if prefix is null.");
+	}
+
+	@Test
+	public void testAddPrefixToSubjectIgnoresPrefixIfAlreadyPresent() {
+		assertEquals(EXPECTED_SUBJECT, EmailUtils.addPrefixToSubject(EXPECTED_SUBJECT, PREFIX),
+				"Prefix is ignored if it was already added to the subject.");
+	}
+
+}

--- a/src/test/java/org/octri/messaging/email/SmtpEmailDeliveryStrategyTest.java
+++ b/src/test/java/org/octri/messaging/email/SmtpEmailDeliveryStrategyTest.java
@@ -3,15 +3,18 @@ package org.octri.messaging.email;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.octri.messaging.autoconfig.EmailProperties;
 import org.octri.messaging.exception.UnsuccessfulDeliveryException;
 import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.SimpleMailMessage;
@@ -20,6 +23,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 @ExtendWith(MockitoExtension.class)
 public class SmtpEmailDeliveryStrategyTest {
 
+	private static final String DEFAULT_SENDER = "default@example.com";
 	private static final String EXPECTED_SENDER = "sender@example.com";
 	private static final String EXPECTED_RECIPIENT = "recipient@example.com";
 	private static final String EXPECTED_SUBJECT = "Subject";
@@ -28,16 +32,31 @@ public class SmtpEmailDeliveryStrategyTest {
 	@Mock
 	JavaMailSender mockMailSender;
 
+	EmailProperties emailProperties;
+
+	@BeforeEach
+	public void setup() {
+		emailProperties = new EmailProperties();
+		emailProperties.setDefaultSenderAddress(DEFAULT_SENDER);
+	}
+
 	@Test
 	public void testRequiresJavaMailSender() {
 		assertThrows(IllegalArgumentException.class, () -> {
-			new SmtpEmailDeliveryStrategy(null);
-		});
+			new SmtpEmailDeliveryStrategy(null, emailProperties);
+		}, "The JavaMailSender should be required.");
+	}
+
+	@Test
+	public void testRequiresEmailProperties() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			new SmtpEmailDeliveryStrategy(mockMailSender, null);
+		}, "The email configuration properties should be required.");
 	}
 
 	@Test
 	public void testMessageConstruction() {
-		var strategy = new SmtpEmailDeliveryStrategy(mockMailSender);
+		var strategy = new SmtpEmailDeliveryStrategy(mockMailSender, emailProperties);
 		var argument = ArgumentCaptor.forClass(SimpleMailMessage.class);
 
 		var result = strategy.sendEmail(EXPECTED_SENDER, EXPECTED_RECIPIENT, EXPECTED_SUBJECT, EXPECTED_BODY);
@@ -45,19 +64,58 @@ public class SmtpEmailDeliveryStrategyTest {
 		verify(mockMailSender).send(argument.capture());
 
 		var message = argument.getValue();
-		assertEquals(EXPECTED_SENDER, message.getFrom());
-		assertEquals(1, message.getTo().length);
-		assertEquals(EXPECTED_RECIPIENT, message.getTo()[0]);
-		assertEquals(EXPECTED_SUBJECT, message.getSubject());
-		assertEquals(EXPECTED_BODY, message.getText());
+		assertEquals(EXPECTED_SENDER, message.getFrom(), "The message should have the expected sender.");
+		assertEquals(1, message.getTo().length, "The message should have one recipient.");
+		assertEquals(EXPECTED_RECIPIENT, message.getTo()[0], "The message should have the expected recipient.");
+		assertEquals(EXPECTED_SUBJECT, message.getSubject(), "The message should have the expected subject.");
+		assertEquals(EXPECTED_BODY, message.getText(), "The message should have the expected text.");
 
 		assertFalse(result.isPresent(), "No delivery details should be returned.");
 	}
 
 	@Test
+	public void testDefaultSender() {
+		var strategy = new SmtpEmailDeliveryStrategy(mockMailSender, emailProperties);
+		var argument = ArgumentCaptor.forClass(SimpleMailMessage.class);
+
+		strategy.sendEmail(EXPECTED_RECIPIENT, EXPECTED_SUBJECT, EXPECTED_BODY);
+		verify(mockMailSender).send(argument.capture());
+
+		var message = argument.getValue();
+		assertEquals(DEFAULT_SENDER, message.getFrom(), "The default sender should be used.");
+	}
+
+	@Test
+	public void testThrowsErrorIfDefaultSenderIsMissing() {
+		var strategy = new SmtpEmailDeliveryStrategy(mockMailSender, emailProperties);
+		emailProperties.setDefaultSenderAddress(null);
+
+		var thrown = assertThrows(UnsuccessfulDeliveryException.class, () -> {
+			strategy.sendEmail(EXPECTED_RECIPIENT, EXPECTED_SUBJECT, EXPECTED_BODY);
+		});
+
+		assertTrue(thrown.getMessage().contains("default sender address is required"),
+				"The error should explain why delivery failed.");
+	}
+
+	@Test
+	public void testSubjectPrefix() {
+		var prefix = "secure:";
+		var strategy = new SmtpEmailDeliveryStrategy(mockMailSender, emailProperties);
+		var argument = ArgumentCaptor.forClass(SimpleMailMessage.class);
+		emailProperties.setSubjectPrefix("secure:");
+
+		strategy.sendEmail(EXPECTED_SENDER, EXPECTED_RECIPIENT, EXPECTED_SUBJECT, EXPECTED_BODY);
+		verify(mockMailSender).send(argument.capture());
+
+		var message = argument.getValue();
+		assertEquals(prefix + " " + EXPECTED_SUBJECT, message.getSubject());
+	}
+
+	@Test
 	public void testExceptionConversion() {
 		var expectedMessage = "Fake auth exception";
-		var strategy = new SmtpEmailDeliveryStrategy(mockMailSender);
+		var strategy = new SmtpEmailDeliveryStrategy(mockMailSender, emailProperties);
 		doThrow(new MailAuthenticationException(expectedMessage)).when(mockMailSender)
 				.send(any(SimpleMailMessage.class));
 


### PR DESCRIPTION
# Overview

Add configurable email subject prefix. If configured, this is prepended to the subject of outgoing email messages.

## Issues

[CIS-3351](https://jirabp.ohsu.edu/browse/CIS-3351)

[X] Added to CHANGELOG.md

## Discussion

While working on this, I noted that we're accumulating a number of configuration properties to configure sender email addresses (`octri.notifications.email`, `octri.authentication.account-message-email`). Having a single place to configure this would be ideal, so I added a configuration property for a default sender address. I'm planning to update AuthLib to fall back to the value of `octri.messaging.default-sender-address` if `octri.authentication.account-message-email` isn't set.