### PR TITLE
Publish SNAPSHOT Artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
   publish:
     name: Publish to Maven Central
     needs: build-java-source
-    if: github.ref_type == 'tag'
+    if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Publish -SNAPSHOT releases to Maven Central.
+
 ## [0.2.0] - 2025-10-01
 
 ### Added


### PR DESCRIPTION
# Overview

Update the GitHub Actions build workflow to publish -SNAPSHOT artifacts to Maven Central, in addition to GitHub Packages.

## Issues

N/A

[X] Added to CHANGELOG.md

## Discussion

In response to our discussion about publishing snapshots to facilitate library testing, I reviewed the [Maven Central documentation](https://central.sonatype.org/publish/publish-portal-snapshots/#enabling-snapshot-releases-for-your-namespace). For our repositories, this essentially involves checking a box in the configuration for our Maven Central namespace and changing one line of the GitHub Actions workflow. This PR is intended as a proof of concept and example of how to update our other library repositories.