### PR TITLE
CIS-3368 Configure Central Snapshots URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Publish -SNAPSHOT releases to Maven Central.
+- Publish -SNAPSHOT releases to Maven Central. (CIS-3368)
 
 ## [0.2.0] - 2025-10-01
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
 							<publishingServerId>central</publishingServerId>
 							<deploymentName>${project.name} ${project.version}</deploymentName>
 							<autoPublish>true</autoPublish>
+							<centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
# Overview

Configure the `centralSnapshotsUrl` for publishing to Maven Central. This attempts to fix an issue where `central-publishing-maven-plugin` is trying to publish to GitHub Packages.

## Issues

CIS-3368

[X] Added to CHANGELOG.md

## Discussion

As noted in the overview, the `central-publishing-maven-plugin` tried to publish to GitHub Packages during the last build ([see here](https://github.com/OHSU-OCTRI/messaging-lib/actions/runs/18175342335/job/51739876580)). The [plugin's documentation](https://central.sonatype.org/publish/publish-portal-maven/#centralsnapshotsurl) says that it "falls back to Maven <distributionManagement> settings" if the `centralSnapshotsUrl` property is not set, so maybe this will fix it.

This is probably the last thing I will try today, but I'll definitely get this figured out in the next few days.
