### PR TITLE
CIS-3455 Fix NPE in Property Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Publish -SNAPSHOT releases to Maven Central. (CIS-3368)
 
+### Fixed
+
+- Fix `NullPointerException` when none of the `octri.messaging.email.*` properties are configured. (CIS-3455)
+
 ## [0.2.0] - 2025-10-01
 
 ### Added

--- a/src/main/java/org/octri/messaging/autoconfig/MessagingConfig.java
+++ b/src/main/java/org/octri/messaging/autoconfig/MessagingConfig.java
@@ -143,7 +143,7 @@ public class MessagingConfig {
 	 */
 	private void validateProperties() {
 		var emailProperties = messagingProperties.getEmail();
-		if (StringUtils.isBlank(emailProperties.getDefaultSenderAddress())) {
+		if (emailProperties == null || StringUtils.isBlank(emailProperties.getDefaultSenderAddress())) {
 			log.warn("The octri.messaging.email.default-sender-address property is blank. "
 					+ "This will cause exceptions if you send messages without specifying a sender.");
 		}

--- a/src/main/java/org/octri/messaging/autoconfig/MessagingProperties.java
+++ b/src/main/java/org/octri/messaging/autoconfig/MessagingProperties.java
@@ -56,7 +56,7 @@ public class MessagingProperties {
 	/**
 	 * Properties to configure the email delivery strategy.
 	 */
-	private EmailProperties email;
+	private EmailProperties email = new EmailProperties();
 
 	/**
 	 * How email messages should be delivered. Defaults to sending messages to the log.
@@ -94,7 +94,7 @@ public class MessagingProperties {
 
 	/**
 	 * Gets the email configuration properties.
-	 * 
+	 *
 	 * @return email configuration
 	 */
 	public EmailProperties getEmail() {
@@ -103,7 +103,7 @@ public class MessagingProperties {
 
 	/**
 	 * Sets the email configuration properties.
-	 * 
+	 *
 	 * @param email
 	 *            email configuration
 	 */

--- a/src/test/java/org/octri/messaging/autoconfig/MessagingConfigTest.java
+++ b/src/test/java/org/octri/messaging/autoconfig/MessagingConfigTest.java
@@ -1,0 +1,42 @@
+package org.octri.messaging.autoconfig;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+public class MessagingConfigTest {
+
+	@Test
+	public void testValidatePropertiesDoesNotWarnWhenDefaultSenderAddressSet(CapturedOutput output) {
+		MessagingProperties properties = new MessagingProperties();
+		properties.getEmail().setDefaultSenderAddress("test@example.com");
+		new MessagingConfig(properties);
+		assertFalse(output.getOut().contains("default-sender-address property is blank"),
+				"Output should not include warning about missing default-sender-address");
+	}
+
+	@Test
+	public void testValidatePropertiesWarnsWhenDefaultSenderAddressMissing(CapturedOutput output) {
+		MessagingProperties properties = new MessagingProperties();
+		new MessagingConfig(properties);
+		assertTrue(output.getOut().contains("default-sender-address property is blank"),
+				"Output should include warning about missing default-sender-address");
+	}
+
+	@Test
+	public void testValidatePropertiesDoesNotThrowWhenEmailConfigMissing() {
+		MessagingProperties properties = new MessagingProperties();
+		properties.setEmail(null);
+
+		Assertions.assertDoesNotThrow(() -> {
+			new MessagingConfig(properties);
+		}, "validateProperties should not throw an exception when email config is not explicitly set");
+	}
+
+}


### PR DESCRIPTION
# Overview

Fix `NullPointerException` in property validation when none of the `octri.messaging.email.*` properties are configured.

## Issues

[CIS-3455](https://jirabp.ohsu.edu/browse/CIS-3455)

[X] Added to CHANGELOG.md

## Discussion

Found while testing baseline survey notifications for COMPASS.
